### PR TITLE
build: upgrade JDK to 21

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'temurin'
       - name: Build and Publish
         uses: gradle/gradle-build-action@v2

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -30,7 +30,7 @@ tasks.named<Jar>("javadocJar") {
 }
 
 kotlin {
-    jvmToolchain(17)
+    jvmToolchain(21)
     compilerOptions {
         freeCompilerArgs = listOf("-Xjsr305=strict", "-Xjvm-default=all")
     }


### PR DESCRIPTION
Upgrade JDK to 21, and use JDK 21 to build this project, which is an LTS version

https://openjdk.org/projects/jdk/21/