### PR TITLE
fix: update publish script

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: gradle/actions/setup-gradle@v3
 
       - name: Build and Publish
-        run: ./gradlew build publis
+        run: ./gradlew build publish
         env:
           OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
           OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}


### PR DESCRIPTION
I noticed a typo in the script command of the [previous PR](https://github.com/ocpddev/slf4k/pull/36), where `publish` was misspelled as `publis`

This PR fixes that




